### PR TITLE
fix: force Django version >= 5.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.2
+Django>=5.2.2
 djangorestframework==3.16
 django-extensions==4.1
 django-allauth[socialaccount]==65.7


### PR DESCRIPTION
## Description

Force Django version >= 5.2.2 according to GHSA-8j24-cjrq-gr2m and GHSA-7xr5-9hcq-chf9 security alerts

## Type of Change

Security Update

## Checklist

- [x] Tests added or updated and passing
- [x] Code follows the project's coding style
- [x] Changes have been validated locally

## Related Links

Closes: GHSA-8j24-cjrq-gr2m
Closes: GHSA-7xr5-9hcq-chf9